### PR TITLE
package: add repo field

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "author": "Hank Stoever",
   "license": "MIT",
-  "homepage": "https://github.com/hstove/electron-cookies",
+  "repository": "hstove/electron-cookies",
   "devDependencies": {
     "chai": "^2.3.0",
     "grunt": "^0.4.5",


### PR DESCRIPTION
So npm add links to source. `homepage` is automatically set, so can be omitted. Thanks!
