### PR TITLE
Handle getting cookies after clearCookies

### DIFF
--- a/spec/electron_cookies_spec.coffee
+++ b/spec/electron_cookies_spec.coffee
@@ -12,8 +12,10 @@ describe 'document.cookies', ->
     expect(document.cookie).to.eql('blah; key=value')
     document.cookie = 'key2=value2'
     expect(document.cookie).to.eql('blah; key=value; key2=value2')
+
 describe 'document.clearCookies', ->
   it 'should clear cookies', ->
     expect(document.clearCookies()).to.eql(true)
     document.cookie = 'key2=value2'
     expect(document.clearCookies()).to.eql(true)
+    expect(document.cookie).to.eql('')

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -1,7 +1,7 @@
 do (document) ->
   localStorage.cookies ||= '{}'
   document.__defineGetter__ 'cookie', ->
-    cookies = JSON.parse(localStorage.cookies)
+    cookies = JSON.parse(localStorage.cookies || '{}')
     output = []
     for cookieName, val of cookies
       validName = cookieName && cookieName.length > 0

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@
     localStorage.cookies || (localStorage.cookies = '{}');
     document.__defineGetter__('cookie', function() {
       var cookieName, cookies, output, res, val, validName;
-      cookies = JSON.parse(localStorage.cookies);
+      cookies = JSON.parse(localStorage.cookies || '{}');
       output = [];
       for (cookieName in cookies) {
         val = cookies[cookieName];


### PR DESCRIPTION
After calling document.clearCookies, document.cookie becomes undefined instead of the default value it was initialized as.
